### PR TITLE
Added init call to module.

### DIFF
--- a/android/src/main/java/com/reactnativegeth/RNGethPackage.java
+++ b/android/src/main/java/com/reactnativegeth/RNGethPackage.java
@@ -29,6 +29,7 @@ public class RNGethPackage implements ReactPackage {
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();
 
+        RNGethModule.init();
         modules.add(new RNGethModule(reactContext));
 
         return modules;


### PR DESCRIPTION
Added missing call to `RNGethModule.init()` for android code. The node would not start for me without this. 