### PR TITLE
Support larger transaction amounts by using a string

### DIFF
--- a/android/src/main/java/com/reactnativegeth/RNGethModule.java
+++ b/android/src/main/java/com/reactnativegeth/RNGethModule.java
@@ -452,19 +452,21 @@ public class RNGethModule extends ReactContextBaseJavaModule {
      */
     @ReactMethod
     public void createAndSendTransaction(String passphrase, double nonce, String toAddress,
-                                         double amount, double gasLimit, double gasPrice,
+                                         String amount, double gasLimit, double gasPrice,
                                          String data, Promise promise) {
         try {
             Account acc = GethHolder.getAccount();
             Address fromAddress = acc.getAddress();
             BigInt chain = new BigInt(GethHolder.getNodeConfig().getEthereumNetworkID());
             Context ctx = new Context();
+            BigInt bigIntAmount = new BigInt(0);
+            bigIntAmount.setString(amount, 10);
             if (nonce == -1) nonce = GethHolder.getNode().getEthereumClient()
                 .getPendingNonceAt(ctx, fromAddress);
             Transaction tx = new Transaction(
                     (long) nonce,
                     new Address(toAddress),
-                    new BigInt((long) amount),
+                    bigIntAmount,
                     (long) gasLimit,
                     new BigInt((long) gasPrice),
                     data.getBytes("UTF8"));


### PR DESCRIPTION
Right now there is a max transaction size of 9.2 ETH due to long overflows. https://github.com/ethereum/go-ethereum/issues/16337

I think we should make the amount a string instead of a double which will prevent these overflows. Here's what I'm using right now - if it looks good I am happy to change over the docs + iOS side as well